### PR TITLE
Fixed element jumps to left on scrolling when right floated

### DIFF
--- a/jquery.lockfixed.js
+++ b/jquery.lockfixed.js
@@ -47,6 +47,9 @@
 				$(window).bind('scroll resize orientationchange load',el,function(e){
 					var el_height = el.outerHeight(),
 						scroll_top = $(window).scrollTop();
+					
+					// check height on load event (specifically) due to elements being hidden on DOM ready - is this case, the height value is incorrect)
+					max_height = $(document).height() - config.offset.bottom;
 
 					//if we have a input focus don't change this (for ios zoom and stuff)
 					if(pos_not_fixed && document.activeElement && document.activeElement.nodeName === "INPUT"){


### PR DESCRIPTION
There is an offset().left measurement (el_left) but it is not used. Added el_right_float variable - if true, el_left is used to position the fixed element correctly in the horizontal axis.

(Yvo, does this work correctly for you without this amendment?)
